### PR TITLE
Added the scale callbacks.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,6 +54,15 @@ class _CropperScreenState extends State<CropperScreen> {
                         overlayType: _overlayType,
                         rotationTurns: _rotationTurns,
                         image: Image.memory(_imageToCrop!),
+                        onScaleStart: (details) {
+                          // todo: define started action.
+                        },
+                        onScaleUpdate: (details) {
+                          // todo: define updated action.
+                        },
+                        onScaleEnd: (details) {
+                          // todo: define ended action.
+                        },
                       )
                     : const ColoredBox(color: Colors.grey),
               ),

--- a/lib/cropperx.dart
+++ b/lib/cropperx.dart
@@ -37,6 +37,15 @@ class Cropper extends StatefulWidget {
   /// The image to crop.
   final Image image;
 
+  /// The called when scale start.
+  final GestureScaleStartCallback? onScaleStart;
+
+  /// The called when scale update.
+  final GestureScaleUpdateCallback? onScaleUpdate;
+
+  /// The called when scale end.
+  final GestureScaleEndCallback? onScaleEnd;
+
   const Cropper({
     Key? key,
     this.backgroundColor = const Color(0xFFCECECE),
@@ -46,6 +55,9 @@ class Cropper extends StatefulWidget {
     this.gridLineThickness = 2.0,
     this.aspectRatio = 1,
     this.rotationTurns = 0,
+    this.onScaleStart,
+    this.onScaleUpdate,
+    this.onScaleEnd,
     required this.cropperKey,
     required this.image,
   }) : super(key: key);
@@ -152,6 +164,9 @@ class _CropperState extends State<Cropper> {
                         ),
                         minScale: 0.1,
                         maxScale: widget.zoomScale,
+                        onInteractionStart: widget.onScaleStart,
+                        onInteractionUpdate: widget.onScaleUpdate,
+                        onInteractionEnd: widget.onScaleEnd,
                       );
                     },
                   ),


### PR DESCRIPTION
While I was developing using CropperX, there was a case where I needed a scale related callback.

For example, if you are using a cropper, change any other widget, When you have finished using the cropper, It is to change the widget that has been changed back to its original state.

For this task, CropperX was used as a child of GestureDetector, but some gesture callbacks did not work properly due to the InteractiveViewer being used inside CropperX, so it was solved by adding callbacks directly to InteractiveViewer.

I think this change will help you meet different development needs.