### PR TITLE
Center the image inside the interactive area

### DIFF
--- a/lib/cropperx.dart
+++ b/lib/cropperx.dart
@@ -211,13 +211,38 @@ class _CropperState extends State<Cropper> {
         : outside.height / inside.height;
   }
 
+  double _getTranslationX(Size outside, Size inside, coverRatio) {
+    if (coverRatio < 1) {
+      return (outside.width / coverRatio - inside.width) / 2;
+    } else {
+      return (outside.width - inside.width / coverRatio) / 2;
+    }
+  }
+
+  double _getTranslationY(Size outside, Size inside, coverRatio) {
+    if (coverRatio < 1) {
+      return (outside.height / coverRatio - inside.height) / 2;
+    } else {
+      return (outside.height - inside.height / coverRatio) / 2;
+    }
+  }
+
   void _setInitialScale(BuildContext context, Size parentSize) {
     WidgetsBinding.instance?.addPostFrameCallback((_) {
       final renderBox = context.findRenderObject() as RenderBox?;
       final childSize = renderBox?.size ?? Size.zero;
       if (childSize != Size.zero) {
-        _transformationController.value =
-            Matrix4.identity() * _getCoverRatio(parentSize, childSize);
+        final coverRatio = _getCoverRatio(parentSize, childSize);
+        Matrix4 value = Matrix4.identity() * coverRatio;
+
+        // Center the image inside the InteractiveViewer
+        value.translate(
+            _getTranslationX(parentSize, childSize, coverRatio),
+            _getTranslationY(parentSize, childSize, coverRatio),
+            0.0
+        );
+
+        _transformationController.value = value;
       }
 
       _shouldSetInitialScale = false;

--- a/lib/cropperx.dart
+++ b/lib/cropperx.dart
@@ -212,19 +212,11 @@ class _CropperState extends State<Cropper> {
   }
 
   double _getTranslationX(Size outside, Size inside, coverRatio) {
-    if (coverRatio < 1) {
-      return (outside.width / coverRatio - inside.width) / 2;
-    } else {
-      return (outside.width - inside.width / coverRatio) / 2;
-    }
+    return (outside.width / coverRatio - inside.width) / 2;
   }
 
   double _getTranslationY(Size outside, Size inside, coverRatio) {
-    if (coverRatio < 1) {
-      return (outside.height / coverRatio - inside.height) / 2;
-    } else {
-      return (outside.height - inside.height / coverRatio) / 2;
-    }
+    return (outside.height / coverRatio - inside.height) / 2;
   }
 
   void _setInitialScale(BuildContext context, Size parentSize) {


### PR DESCRIPTION
This PR centers the image (blue in the illustration below) inside the interactive area (red in the illustration below) on widget initialization.

Before (master)|After (this PR)
------|------
![cropperx_center_before](https://user-images.githubusercontent.com/4425455/160725512-071f777b-8c60-45d7-bba0-89326ae8f5df.png)|![cropperx_center_after](https://user-images.githubusercontent.com/4425455/160725537-6fbeebd3-d460-4e52-bb93-33ac1debbb20.png)



I think it feels more natural in most of the use cases.